### PR TITLE
Add a start index field

### DIFF
--- a/examples/rich-text/src/main.rs
+++ b/examples/rich-text/src/main.rs
@@ -144,7 +144,7 @@ fn main() {
         editor
             .buffer_mut()
             .lines
-            .push(TextLayoutLine::new(line_text, attrs_list));
+            .push(TextLayoutLine::new(line_text, attrs_list, 0));
     }
 
     let mut attrs = AttrsList::new(Attrs::new());

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -553,6 +553,7 @@ impl TextLayout {
     pub fn set_text(&mut self, text: &str, attrs: AttrsList) {
         self.lines.clear();
         let mut attrs = attrs;
+        let mut start_index = 0;
         for line in text.split_terminator('\n') {
             let l = line.len();
             let (line, had_r) = if l > 0 && line.as_bytes()[l - 1] == b'\r' {
@@ -561,13 +562,19 @@ impl TextLayout {
                 (line, false)
             };
             let new_attrs = attrs.split_off(line.len() + 1 + if had_r { 1 } else { 0 });
-            self.lines
-                .push(TextLayoutLine::new(line.to_string(), attrs.clone()));
+            self.lines.push(TextLayoutLine::new(
+                line.to_string(),
+                attrs.clone(),
+                start_index,
+            ));
             attrs = new_attrs;
+
+            start_index += l + 1 + if had_r { 1 } else { 0 };
         }
         // Make sure there is always one line
         if self.lines.is_empty() {
-            self.lines.push(TextLayoutLine::new(String::new(), attrs));
+            self.lines
+                .push(TextLayoutLine::new(String::new(), attrs, 0));
         }
 
         self.scroll = 0;

--- a/src/buffer_line.rs
+++ b/src/buffer_line.rs
@@ -11,6 +11,8 @@ pub struct TextLayoutLine {
     attrs_list: AttrsList,
     wrap: Wrap,
     align: Option<Align>,
+    /// The index into the original text where this line starts
+    start_index: usize,
     shape_opt: Option<ShapeLine>,
     layout_opt: Option<Vec<LayoutLine>>,
 }
@@ -19,12 +21,13 @@ impl TextLayoutLine {
     /// Create a new line with the given text and attributes list
     /// Cached shaping and layout can be done using the [`Self::shape`] and
     /// [`Self::layout`] functions
-    pub fn new<T: Into<String>>(text: T, attrs_list: AttrsList) -> Self {
+    pub fn new<T: Into<String>>(text: T, attrs_list: AttrsList, start_index: usize) -> Self {
         Self {
             text: text.into(),
             attrs_list,
             wrap: Wrap::Word,
             align: None,
+            start_index,
             shape_opt: None,
             layout_opt: None,
         }
@@ -117,6 +120,11 @@ impl TextLayoutLine {
         }
     }
 
+    /// The start index in the original overarching line.
+    pub fn start_index(&self) -> usize {
+        self.start_index
+    }
+
     /// Append line at end of this line
     ///
     /// The wrap setting of the appended line will be lost
@@ -145,7 +153,7 @@ impl TextLayoutLine {
         let attrs_list = self.attrs_list.split_off(index);
         self.reset();
 
-        let mut new = Self::new(text, attrs_list);
+        let mut new = Self::new(text, attrs_list, self.start_index + index);
         new.wrap = self.wrap;
         new
     }

--- a/src/edit/editor.rs
+++ b/src/edit/editor.rs
@@ -243,6 +243,7 @@ impl Edit for Editor {
                     .strip_suffix(char::is_control)
                     .unwrap_or(data_line),
                 these_attrs,
+                0, // TODO(minor): incorrect start index
             ));
         } else {
             panic!("str::lines() did not yield any elements");
@@ -254,6 +255,7 @@ impl Edit for Editor {
                     .strip_suffix(char::is_control)
                     .unwrap_or(data_line),
                 final_attrs.split_off(remaining_split_len),
+                0, // TODO(minor): incorrect start index
             );
             tmp.append(after);
             self.buffer.lines.insert(insert_line, tmp);
@@ -268,6 +270,7 @@ impl Edit for Editor {
                     .strip_suffix(char::is_control)
                     .unwrap_or(data_line),
                 final_attrs.split_off(remaining_split_len),
+                0, // TODO(minor): incorrect start index
             );
             self.buffer.lines.insert(insert_line, tmp);
             self.cursor.line += 1;


### PR DESCRIPTION
This adds a new field to `TextLayoutLine` that is the original line's starting index in the original text.   
This is useful for mapping indices within the text layout back to indices within the original line, and thus the original file.  
  
I don't currently set the `start_index` in the editor. It is rather intricate, so getting the right index would be a bit of a challenge, but also we simply don't use the `Editor` logic in cosmic as far as I know.  